### PR TITLE
Fix GitHub capitalisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 An Open Source community, dedicated to Open Source projects
 
-[![License][1]][2] [![Github Repo Size][3]][4] [![Github Contributors][5]][6] [![Github Last Commit][7]][8]
+[![License][1]][2] [![GitHub Repo Size][3]][4] [![GitHub Contributors][5]][6] [![GitHub Last Commit][7]][8]
 
 </div>
 

--- a/data/FooterLinks.js
+++ b/data/FooterLinks.js
@@ -22,7 +22,7 @@ const FooterLinks = [
     title: "Links",
     data: [
       {
-        text: "Github",
+        text: "GitHub",
         url: "https://github.com/codinasion",
       },
       {

--- a/pages/projects/awesome-profile/index.js
+++ b/pages/projects/awesome-profile/index.js
@@ -61,13 +61,13 @@ export default function AwesomeProfile({ profiles }) {
     <>
       <Seo
         title="Awesome Profile Readme"
-        description="Here is the list of awesome github profile READMEs submitted by the community. You can also add your profile by clicking the ADD PROFILE Button."
+        description="Here is the list of awesome GitHub profile READMEs submitted by the community. You can also add your profile by clicking the ADD PROFILE Button."
       />
       <Container disableGutters maxWidth="lg" component="main" sx={{ p: 3 }}>
         <Grid container spacing={3} alignItems="stretch">
           <Grid item xs={12} sm={7} style={{ display: "flex" }}>
             <Typography variant="body1" color="black" paragraph>
-              Here is the list of awesome github profile READMEs submitted by
+              Here is the list of awesome GitHub profile READMEs submitted by
               the community.
               <br />
               You can also add your profile by clicking the &apos;ADD


### PR DESCRIPTION
### Why:

The correct spelling for GitHub is Git**H**ub, not Git**h**ub.

### What's being changed:

Correct Git*H*ub throughout the repo.